### PR TITLE
Add magmom support for write_fleur_input

### DIFF
--- a/ase_fleur/io.py
+++ b/ase_fleur/io.py
@@ -334,7 +334,10 @@ def write_fleur_inpgen(
     -------
     """
 
-    atom_sites = [AtomSiteProperties(position=atom.position, symbol=atom.symbol, kind=atom.symbol) for atom in atoms]
+    if any(atom.magmom for atom in atoms):
+        atom_sites = [AtomSiteProperties(position=atom.position, symbol=atom.symbol, kind=atom.symbol, magnetic_moment=atom.magmom) for atom in atoms]
+    else:
+        atom_sites = [AtomSiteProperties(position=atom.position, symbol=atom.symbol, kind=atom.symbol) for atom in atoms]
 
     write_inpgen_file(
         atoms.cell,


### PR DESCRIPTION
The `write_fleur_inpgen` now supports reading magnetic moments from ASE objects and writing them directly into the inpgen input. This ensures that atomic spin configurations are properly initialized in the generated `inp.xml` file.

If magnetic moments (magmoms) are specified, they are written directly into the inpgen input file. For atoms without assigned magmoms, a value of 0 is used.   
If no magmoms are provided, inpgen automatically determines the spin state of the system — for example, setting jspins=2 by default for iron (Fe). 
     